### PR TITLE
Add Avalance Fuji support when switching networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ REACT_APP_SUBGRAPHQL_URL=https://api.thegraph.com/subgraphs/name/kenchangh/ribbo
 REACT_APP_KOVAN_SUBGRAPHQL_URL=https://api.thegraph.com/subgraphs/name/kenchangh/ribbon-finance-kovan
 REACT_APP_AIRTABLE_API_KEY=keymgnfgwnQHmH4pl
 REACT_APP_AIRTABLE_BASE_ID=app5c70grFW2INfkN
+REACT_APP_AVAX_URI=https://api.avax.network/ext/bc/C/rpc
+REACT_APP_FUJI_URI=https://api.avax-test.network/ext/bc/C/rpc
+REACT_APP_AVAX_SUBGRAPHQL_URL=https://api.thegraph.com/subgraph/name/kenchangh/ribbon-avax
 ```
 
 In order to switch between the development environment and a production environment, we can change the `REACT_APP_VERCEL_GIT_COMMIT_REF` env var.

--- a/shared/src/constants/chainParameters.ts
+++ b/shared/src/constants/chainParameters.ts
@@ -22,3 +22,15 @@ export const AVALANCHE_MAINNET_PARAMS: AddEthereumChainParameter = {
   rpcUrls: ["https://api.avax.network/ext/bc/C/rpc"],
   blockExplorerUrls: ["https://snowtrace.io/"],
 };
+
+export const AVALANCHE_TESTNET_PARAMS: AddEthereumChainParameter = {
+  chainId: "0xA869",
+  chainName: "Avalanche Fuji C-Chain",
+  nativeCurrency: {
+    name: "Avalanche",
+    symbol: "AVAX",
+    decimals: 18,
+  },
+  rpcUrls: ["https://api.avax-test.network/ext/bc/C/rpc"],
+  blockExplorerUrls: ["https://testnet.snowtrace.io/"],
+};

--- a/shared/src/constants/constants.ts
+++ b/shared/src/constants/constants.ts
@@ -37,6 +37,9 @@ export const READABLE_NETWORK_NAMES: Record<CHAINID, string> = {
 export const isEthNetwork = (chainId: number): boolean =>
   chainId === CHAINID.ETH_MAINNET || chainId === CHAINID.ETH_KOVAN;
 
+export const isAvaxNetwork = (chainId: number): boolean =>
+  chainId === CHAINID.AVAX_MAINNET || chainId === CHAINID.AVAX_FUJI;
+
 export const NATIVE_TOKENS = ["WETH", "WAVAX"];
 export const isNativeToken = (token: string): boolean =>
   NATIVE_TOKENS.includes(token);

--- a/shared/src/utils/chainSwitching.ts
+++ b/shared/src/utils/chainSwitching.ts
@@ -1,5 +1,6 @@
 import { providers } from "ethers";
-import { AVALANCHE_MAINNET_PARAMS } from "../constants/chainParameters";
+import { AVALANCHE_MAINNET_PARAMS, AVALANCHE_TESTNET_PARAMS } from "../constants/chainParameters";
+import { isAvaxNetwork } from "../constants/constants";
 import { CHAINID } from "./env";
 
 // This error code indicates that the chain has not been added to MetaMask.
@@ -28,11 +29,11 @@ export const switchChains = async (
         switchError.data.originalError &&
         switchError.data.originalError.code === UNAVAILABLE_CHAIN_CODE)
     ) {
-      if (chainId === CHAINID.AVAX_MAINNET) {
+      if (isAvaxNetwork(chainId)) {
         try {
           await provider.provider.request({
             method: "wallet_addEthereumChain",
-            params: [AVALANCHE_MAINNET_PARAMS],
+            params: [chainId === CHAINID.AVAX_MAINNET ? AVALANCHE_MAINNET_PARAMS : AVALANCHE_TESTNET_PARAMS],
           });
         } catch (addError) {
           // handle "add" error

--- a/webapp/src/pages/Home/Homepage.tsx
+++ b/webapp/src/pages/Home/Homepage.tsx
@@ -1,16 +1,17 @@
 import { useWeb3React } from "@web3-react/core";
 import React from "react";
 import { useHistory } from "react-router";
-import Banner from "shared/lib/components/Banner/Banner";
 
+import Banner from "shared/lib/components/Banner/Banner";
 import ProductCatalogue from "shared/lib/components/Product/ProductCatalogue";
-import { CHAINID } from "shared/lib/utils/env";
+import { CHAINID, isProduction } from "shared/lib/utils/env";
 import { Title } from "shared/lib/designSystem";
 import sizes from "shared/lib/designSystem/sizes";
 import styled from "styled-components";
 import { ANNOUNCEMENT, getVaultURI } from "../../constants/constants";
 import { switchChains } from "shared/lib/utils/chainSwitching";
 import useScreenSize from "shared/lib/hooks/useScreenSize";
+import { isAvaxNetwork } from "shared/lib/constants/constants";
 
 const ProductTitle = styled(Title)`
   display: none;
@@ -30,7 +31,7 @@ const Homepage = () => {
   return (
     <>
       <ProductTitle>PRODUCT</ProductTitle>
-      {ANNOUNCEMENT && chainId && chainId !== CHAINID.AVAX_MAINNET && (
+      {ANNOUNCEMENT && chainId && !isAvaxNetwork(chainId) && (
         <Banner
           color={ANNOUNCEMENT.color}
           message={ANNOUNCEMENT.message}
@@ -39,7 +40,7 @@ const Homepage = () => {
           onClick={() => {
             (async () => {
               if (library) {
-                await switchChains(library, CHAINID.AVAX_MAINNET);
+                await switchChains(library, isProduction() ? CHAINID.AVAX_MAINNET : CHAINID.AVAX_FUJI);
                 // Mobile wallets normally need to do a hard refresh
                 if (isMobile) {
                   window.location.replace("/");


### PR DESCRIPTION
Add support for Avalance Fuji when switching networks either via the Banner or via the networks button at the top right of the Ribbon app so the AVAX integration in development is on par with production. 

Test by setting `REACT_APP_VERCEL_GIT_COMMIT_REF=development` in `webapp/.env`.