### PR TITLE
Fix missing AVAX balances/tx history in portfolio

### DIFF
--- a/shared/src/hooks/useFetchSubgraphData.ts
+++ b/shared/src/hooks/useFetchSubgraphData.ts
@@ -101,15 +101,15 @@ const useFetchSubgraphData = () => {
 
           responsesForVersion.forEach((response: any) => {
             Object.keys(response).forEach((key: string) => {
-              // Null state = [] | null
-              // Non-empty state = [xxx] | {x: 1}
-              const mergedHasProperty =
-                mergedResponse[key] ||
-                (Array.isArray(mergedResponse[key]) &&
-                  mergedResponse[key].length);
-
-              if (!mergedHasProperty) {
+              // Push response if its an array
+              // Otherwise merge without overriding existing property
+              if (!mergedResponse[key]) {
                 mergedResponse[key] = response[key];
+              } else if (
+                Array.isArray(mergedResponse[key]) &&
+                Array.isArray(response[key])
+              ) {
+                mergedResponse[key].push(...response[key]);
               }
             });
           });


### PR DESCRIPTION
The V2 subgraph data from other chainIds didn't get merged here: https://github.com/ribbon-finance/ribbon-frontend/blob/5ae379c30524754629b3d3abbbb5a80d0f6f6af4/shared/src/hooks/useFetchSubgraphData.ts#L104-L113

Fixed it by pushing the response to the mergedResponse if the response is an array