### PR TITLE
fix/gas-price-rate-limit-crash  Rate limit on gas API causing app to crash

### DIFF
--- a/shared/src/hooks/useGasPrice.ts
+++ b/shared/src/hooks/useGasPrice.ts
@@ -36,7 +36,8 @@ const useGasPrice = () => {
     if (isEthNetwork(chainId)) {
       const response = await axios.get(GAS_URL[chainId]);
       const data: APIResponse = response.data;
-      gasPrice = data.result.FastGasPrice;
+      // If the result is undefined, we got rate limited - so return "0"
+      gasPrice = data.result.FastGasPrice || "0";
     } else if (isAvaxNetwork(chainId)) {
       // Snowtrace API wrongly returns Ethereum mainnet gas price
       // But the good thing is that Avalanche hardcodes gas price to 25 nAVAX (gwei)


### PR DESCRIPTION
- fix/gas-price-rate-limit-crash  Rate limit on gas API causing app to crash

![image](https://user-images.githubusercontent.com/1562849/152449584-74f4cf69-5988-4bd3-bbf7-b0f8f4444c84.png)
