### PR TITLE
Fixed break in treasury pages

### DIFF
--- a/shared/src/hooks/useFetchV2VaultData.ts
+++ b/shared/src/hooks/useFetchV2VaultData.ts
@@ -1,8 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
 import { useWeb3React } from "@web3-react/core";
 import { BigNumber } from "ethers";
-import { EVMVaultList, getVaultNetwork } from "../constants/constants";
-import { isProduction } from "../utils/env";
+import {
+  EVMVaultList,
+  getVaultNetwork,
+  TreasuryVaultList,
+} from "../constants/constants";
+import { isProduction, isTreasury } from "../utils/env";
 import { getV2VaultContract } from "./useV2VaultContract";
 import { impersonateAddress } from "../utils/development";
 import {
@@ -42,8 +46,10 @@ const useFetchV2VaultData = (): V2VaultData => {
       return currentCounter;
     });
 
+    const vaultList = isTreasury() ? TreasuryVaultList : EVMVaultList;
+
     const responses = await Promise.all(
-      EVMVaultList.map(async (vault) => {
+      vaultList.map(async (vault) => {
         const inferredProviderFromVault = getProviderForNetwork(
           getVaultNetwork(vault)
         );

--- a/treasury/src/hooks/useNotifications.ts
+++ b/treasury/src/hooks/useNotifications.ts
@@ -16,7 +16,6 @@ import { useGlobalState } from "shared/lib/store/store";
 import useTransactions from "shared/lib/hooks/useTransactions";
 import { useVaultsPriceHistory } from "shared/lib/hooks/useVaultPerformanceUpdate";
 import { parseUnits } from "ethers/lib/utils";
-import { BigNumber } from "ethers";
 
 const localStorageKey = "notificationLastRead";
 


### PR DESCRIPTION
Issue: Fetching vault data refers to `EVMVaultList` which does not include Treasury Vaults, causing an error
Fix: Added a logic which allows the fetching hook to refer to `TreasuryVaultList` for treasury build