### PR TITLE
More qa items

### DIFF
--- a/governance/src/components/Homepage/OverviewKPI.tsx
+++ b/governance/src/components/Homepage/OverviewKPI.tsx
@@ -127,8 +127,7 @@ const OverviewKPI = () => {
             fully on-chain governance
           </SecondaryText>
           <BaseUnderlineLink
-            // TODO: Replace URL
-            to="https://google.com"
+            to="https://gov.ribbon.finance/t/rgp-9-ribbonomics/486"
             target="_blank"
             rel="noreferrer noopener"
             className={`d-flex mt-4 ${width < sizes.lg ? "mx-auto" : ""}`}
@@ -233,7 +232,7 @@ const OverviewKPI = () => {
           loop
         />
       </FloatingBackgroundContainer>
-      <FloatingBackgroundContainer backgroundColor="#000000E0" />
+      <FloatingBackgroundContainer backgroundColor="#000000CC" />
     </>
   );
 };

--- a/shared/src/components/Common/SegmentControl.tsx
+++ b/shared/src/components/Common/SegmentControl.tsx
@@ -8,7 +8,7 @@ import React, {
 import { Frame } from "framer";
 import styled from "styled-components";
 
-import theme from "../../designSystem/theme";
+import designTheme from "../../designSystem/theme";
 import colors from "../../designSystem/colors";
 import { Subtitle } from "../../designSystem";
 import useElementScroll from "../../hooks/useElementScroll";
@@ -22,7 +22,7 @@ const SegmentControlContainer = styled.div<{
   backgroundColor?: string;
   widthType: WidthType;
 }>`
-  border-radius: ${theme.border.radius};
+  border-radius: ${designTheme.border.radius};
   background-color: ${(props) => {
     if (props.backgroundColor) {
       return props.backgroundColor;
@@ -57,6 +57,8 @@ const SegmentControlContainer = styled.div<{
     }
   }}
 
+  overflow-y: auto;
+
   /* Firefox */
   scrollbar-width: none;
 
@@ -86,7 +88,7 @@ const ContainerScrollIndicator = styled.div<{
   justify-content: center;
   align-items: center;
   background: linear-gradient(270deg, #08090e 40.63%, rgba(8, 9, 14, 0) 100%);
-  border-radius: ${theme.border.radius};
+  border-radius: ${designTheme.border.radius};
   z-index: 2;
   transition: 0.2s all ease-out;
   top: 0;
@@ -113,13 +115,13 @@ const ActiveBackground = styled(Frame)<{
   theme?: "outline";
   color?: string;
 }>`
-  border-radius: ${theme.border.radius} !important;
+  border-radius: ${designTheme.border.radius} !important;
   ${(props) => {
     switch (props.theme) {
       case "outline":
         return `
           transition: 0.25s border ease-out;
-          border: ${theme.border.width} ${theme.border.style} 
+          border: ${designTheme.border.width} ${designTheme.border.style} 
             ${props.color ? props.color : colors.primaryText};
           background-color: transparent !important;
         `;
@@ -228,7 +230,10 @@ const SegmentControl: React.FC<SegmentControlProps> = ({
         left: currentCurrency.offsetLeft,
         top: currentCurrency.offsetTop,
         height: currentCurrency.clientHeight,
-        width: currentCurrency.clientWidth,
+        width:
+          theme === "outline"
+            ? currentCurrency.clientWidth - 1
+            : currentCurrency.clientWidth,
       });
     };
     handleResize();
@@ -238,7 +243,7 @@ const SegmentControl: React.FC<SegmentControlProps> = ({
     return () => {
       window.removeEventListener("resize", handleResize);
     };
-  }, [value, controlRefs]);
+  }, [value, controlRefs, theme]);
 
   const handleScrollLeft = useCallback(() => {
     containerRef.current?.scrollBy({ left: -width, behavior: "smooth" });

--- a/shared/src/hooks/useBalances.ts
+++ b/shared/src/hooks/useBalances.ts
@@ -46,19 +46,11 @@ export const resolveBalancesSubgraphResponse = (responses: {
       : []
   ).sort((a, b) => (a.timestamp > b.timestamp ? 1 : -1));
 
-const useBalances = (before?: number, after?: number) => {
+const useBalances = () => {
   const contextData = useContext(SubgraphDataContext);
-
-  let balances = contextData.vaultSubgraphData.balances;
-  balances = before
-    ? balances.filter((balance) => balance.timestamp <= before)
-    : balances;
-  balances = after
-    ? balances.filter((balance) => balance.timestamp >= after)
-    : balances;
-
+  const balances = contextData.vaultSubgraphData.balances;
   return {
-    balances: balances,
+    balances,
     loading: contextData.vaultSubgraphData.loading,
   };
 };

--- a/webapp/src/components/Common/toasts.tsx
+++ b/webapp/src/components/Common/toasts.tsx
@@ -10,7 +10,11 @@ import {
 } from "shared/lib/constants/constants";
 import { usePendingTransactions } from "shared/lib/hooks/pendingTransactionsContext";
 import { PendingTransaction } from "shared/lib/store/types";
-import { getAssetDecimals, getAssetDisplay } from "shared/lib/utils/asset";
+import {
+  getAssetDecimals,
+  getAssetDisplay,
+  getChainByVaultOption,
+} from "shared/lib/utils/asset";
 import { formatBigNumber, isPracticallyZero } from "shared/lib/utils/math";
 import { capitalize } from "shared/lib/utils/text";
 import { productCopies } from "shared/lib/components/Product/productCopies";
@@ -20,6 +24,7 @@ import { getVaultColor } from "shared/lib/utils/vault";
 import { useV2VaultsData } from "shared/lib/hooks/web3DataContext";
 import { useVaultsPriceHistory } from "shared/lib/hooks/useVaultPerformanceUpdate";
 import { parseUnits } from "ethers/lib/utils";
+import { useChain } from "shared/lib/hooks/chainContext";
 
 /**
  * TODO: Temporary disabled
@@ -219,6 +224,7 @@ export const TxStatusToast = () => {
 
 export const WithdrawReminderToast = () => {
   const { data } = useV2VaultsData();
+  const [chain] = useChain();
   const [reminders, setReminders] = useState<
     {
       vault: { option: VaultOptions; version: VaultVersion };
@@ -234,6 +240,10 @@ export const WithdrawReminderToast = () => {
    */
   useEffect(() => {
     VaultList.forEach((vault) => {
+      // Ignore if the chain is not the current chain
+      if (getChainByVaultOption(vault) !== chain) {
+        return;
+      }
       const vaultData = data[vault as VaultOptions];
       const asset = getAssets(vault as VaultOptions);
       const decimals = getAssetDecimals(asset);
@@ -273,7 +283,7 @@ export const WithdrawReminderToast = () => {
         );
       }
     }, []);
-  }, [data, priceHistories.v2, reminders]);
+  }, [data, priceHistories.v2, reminders, chain]);
 
   /**
    * Make sure index does not goes out of bound

--- a/webapp/src/components/Staking/LiquidityGaugeModal/StakingActionModal.tsx
+++ b/webapp/src/components/Staking/LiquidityGaugeModal/StakingActionModal.tsx
@@ -237,7 +237,7 @@ const StakingActionModal: React.FC<StakingActionModalProps> = ({
       setTxId(txhash);
       addPendingTransaction({
         txhash,
-        type: "unstake",
+        type: "stake",
         amount: input,
         stakeAsset: vaultOption,
       });

--- a/webapp/src/components/Vault/Modal/YourPositionModal.tsx
+++ b/webapp/src/components/Vault/Modal/YourPositionModal.tsx
@@ -282,7 +282,7 @@ const YourPositionModal: React.FC = () => {
       onClose={() =>
         setVaultPositionModal((prev) => ({ ...prev, show: false }))
       }
-      height={500}
+      height={ModeList.length > 1 ? 500 : 420}
     >
       <>
         <AnimatePresence initial={false} exitBeforeEnter>

--- a/webapp/src/components/Vault/VaultActionsForm/common/VaultApprovalForm.tsx
+++ b/webapp/src/components/Vault/VaultActionsForm/common/VaultApprovalForm.tsx
@@ -46,7 +46,6 @@ const ApprovalIcon = styled.div<{ color: string }>`
   align-items: center;
   width: 64px;
   height: 64px;
-  padding: 8px;
   border-radius: 100px;
   background-color: ${(props) => props.color}29;
 `;


### PR DESCRIPTION
- [Ignored withdrawal reminders from other chain](https://www.notion.so/ribbonfinance/Eth-related-toast-appearing-when-connected-to-avalanche-a77107e9637c4e5ba8aa103284141a09)
- [Fixed approval logo smaller than container](https://www.notion.so/ribbonfinance/Vault-logos-are-smaller-than-their-containers-0d9e90c10e7145abab0d1b89b2bbe45d)
- [Fixed edge cases where portfolio chart is showing wrong balances for some users](https://www.notion.so/ribbonfinance/Portfolio-balance-chart-is-different-for-each-time-filter-efdf7c4d21be4c69912e173741fc22e0)
  - Our portfolio chart is using `balanceUpdates` events to get the balances. Some users still have position in v1, and currently there hasn't been any new `balanceUpdates` for v1 in over a month. This causes the month/week filter to ignore the v1 balances.
- Fixed toast showing wrong title when Staking in Liquidity Gauge v5
- [Position modal UI change](https://www.notion.so/ribbonfinance/Non-ETH-position-modal-spacing-issue-df4b4843d3094c888f95e93eec927c75)
- Updated governance learn more url to go to rgp-9