### PR TITLE
fix/speed-up-confirmations Changing the pending transactions confirmations to 1

### DIFF
--- a/shared/src/hooks/pendingTransactionsContext.tsx
+++ b/shared/src/hooks/pendingTransactionsContext.tsx
@@ -66,7 +66,7 @@ export const PendingTransactionsContextProvider: React.FC<{
         if (isEVMChain(chain)) {
           receipt = await (
             ethereumProvider as providers.Web3Provider
-          ).waitForTransaction(transaction.txhash, 5);
+          ).waitForTransaction(transaction.txhash, 1);
         } else if (isSolanaChain(chain)) {
           receipt = await connection.confirmTransaction(
             transaction.txhash,


### PR DESCRIPTION
fix/speed-up-confirmations Changing the pending transactions confirmations to 1

The odds of a reorg attacks are super unlikely and users would rather have speed and optimistic updates are way more user friendly.