### PR TITLE
Used display asset for color and logo

### DIFF
--- a/webapp/src/components/Staking/LiquidityGaugeModal/StakingActionModal.tsx
+++ b/webapp/src/components/Staking/LiquidityGaugeModal/StakingActionModal.tsx
@@ -438,7 +438,7 @@ const StakingActionModal: React.FC<StakingActionModalProps> = ({
             </InfoColumn>
             <InfoColumn marginTop={4}>
               <SecondaryText className="ml-2" fontSize={12}>
-                Boosted Rewards ({apys.boostedMultiplier})
+                Boosted Rewards {apys.boostedMultiplier}
               </SecondaryText>
               <InfoData color={colors.text} fontSize={14}>
                 {apys.boostedRewards}

--- a/webapp/src/components/Staking/RewardsCalculatorModal/RewardsCalculatorModal.tsx
+++ b/webapp/src/components/Staking/RewardsCalculatorModal/RewardsCalculatorModal.tsx
@@ -17,7 +17,7 @@ import {
 } from "shared/lib/models/lockupPeriod";
 import colors from "shared/lib/designSystem/colors";
 import {
-  getAssets,
+  getDisplayAssets,
   VaultLiquidityMiningMap,
   VaultOptions,
 } from "shared/lib/constants/constants";
@@ -136,18 +136,19 @@ const stakingPools = Object.keys(VaultLiquidityMiningMap.lg5) as VaultOptions[];
 const stakingPoolDropdownOptions: StakingPoolOption[] = (
   Object.keys(VaultLiquidityMiningMap.lg5) as VaultOptions[]
 ).map((option) => {
-  const Logo = getAssetLogo(getAssets(option));
+  const Logo = getAssetLogo(getDisplayAssets(option));
   return {
     value: option,
     label: option,
     logo: (
-      <Logo
+      <div
         style={{
-          margin: 0,
           width: 32,
           height: 32,
         }}
-      />
+      >
+        <Logo />
+      </div>
     ),
   };
 });
@@ -459,11 +460,13 @@ const RewardsCalculatorModal: React.FC<RewardsCalculatorModalProps> = ({
                 fontSize={14}
                 fontWeight={500}
                 className="mr-auto"
-                color={colors.asset[getAssets(currentGauge)]}
+                color={colors.asset[getDisplayAssets(currentGauge)]}
               >
                 APY
               </SecondaryText>
-              <CalculationData color={colors.asset[getAssets(currentGauge)]}>
+              <CalculationData
+                color={colors.asset[getDisplayAssets(currentGauge)]}
+              >
                 {displayRewards.totalAPY}
               </CalculationData>
             </CalculationColumn>


### PR DESCRIPTION
- Fixed stETH showing ETH logo previously, because underlying asset logo was used.
<img width="340" alt="Screenshot 2022-03-07 at 1 48 27 PM" src="https://user-images.githubusercontent.com/11567740/156975439-520c7e73-30c3-4d9b-ac32-9cdf2c18c775.png">