### PR TITLE
Fix settlementB explainer

### DIFF
--- a/webapp/src/components/Deposit/VaultStrategyExplainer.tsx
+++ b/webapp/src/components/Deposit/VaultStrategyExplainer.tsx
@@ -956,7 +956,7 @@ const VaultStrategyExplainer: React.FC<VaultStrategyExplainerProps> = ({
         case "settlementB":
           return (
             <>
-              When the call options expire{" "}
+              When the {isPut ? "put" : "call"} options expire{" "}
               <TooltipExplanation
                 title="IN-THE-MONEY"
                 explanation={`An ${optionAssetUnit} ${


### PR DESCRIPTION
Add the `isPut` switch in `settlementB` description.

Without this, for put vaults like `T-YVUSDC-P-ETH`, it is currently showing *call option* in the explainer card for the ITM settlement section.