### PR TITLE
Add boosted multiplier and percentage to gauge card. Refactor repeating texts.

### DIFF
--- a/shared/src/i18n/en/webapp.json
+++ b/shared/src/i18n/en/webapp.json
@@ -47,6 +47,10 @@
     "poolRewards": {
       "title": "Weekly Pool Rewards",
       "description": "Estimated amount of RBN to be distributed for the current week."
+    },
+    "boostedRewards": {
+      "title": "Boosted Rewards",
+      "description": "The additional rewards veRBN holders earn for staking their rTokens. Base rewards can be boosted by up to 2.5X."
     }
   },
   "LiquidityMining": {

--- a/webapp/src/components/Staking/LiquidityGaugeModal/StakingActionModal.tsx
+++ b/webapp/src/components/Staking/LiquidityGaugeModal/StakingActionModal.tsx
@@ -170,7 +170,10 @@ const StakingActionModal: React.FC<StakingActionModalProps> = ({
     }
 
     const boostedMultiplier = calculateBoostedMultipler(
-      parseUnits(input || "0", decimals)
+      // Boosted multiplier needs to factor in the current staked amount.
+      parseUnits(input || "0", decimals).add(
+        stakingPoolData?.currentStake || BigNumber.from(0)
+      )
     );
     const boostedRewards = calculateBoostedRewards(baseAPY, boostedMultiplier);
 
@@ -190,6 +193,7 @@ const StakingActionModal: React.FC<StakingActionModalProps> = ({
     loadingText,
     error,
     input,
+    stakingPoolData,
   ]);
 
   const handleInputChange = useCallback(
@@ -388,11 +392,14 @@ const StakingActionModal: React.FC<StakingActionModalProps> = ({
             <InfoColumn marginTop={4}>
               <ContainerWithTooltip>
                 <SecondaryText className="ml-2" fontSize={12}>
-                  Boosted Rewards {apys.boostedMultiplier}
+                  {t("webapp:TooltipExplanations:boostedRewards:title")}{" "}
+                  {apys.boostedMultiplier}
                 </SecondaryText>
                 <TooltipExplanation
-                  title="Boosted Rewards"
-                  explanation="The additional rewards veRBN holders earn for staking their rTokens. Base rewards can be boosted by up to 2.5X."
+                  title={t("webapp:TooltipExplanations:boostedRewards:title")}
+                  explanation={t(
+                    "webapp:TooltipExplanations:boostedRewards:description"
+                  )}
                   renderContent={({ ref, ...triggerHandler }) => (
                     <HelpInfo containerRef={ref} {...triggerHandler}>
                       i

--- a/webapp/src/components/Staking/RewardsCalculatorModal/RewardsCalculatorModal.tsx
+++ b/webapp/src/components/Staking/RewardsCalculatorModal/RewardsCalculatorModal.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
+import { useTranslation } from "react-i18next";
 
 import BasicModal from "shared/lib/components/Common/BasicModal";
 import {
@@ -166,6 +167,7 @@ const RewardsCalculatorModal: React.FC<RewardsCalculatorModalProps> = ({
   onClose,
 }) => {
   const votingEscrowContract = useVotingEscrow();
+  const { t } = useTranslation();
 
   // Current Gauge
   const [currentGauge, setCurrentGauge] = useState(stakingPools[0]);
@@ -491,11 +493,13 @@ const RewardsCalculatorModal: React.FC<RewardsCalculatorModalProps> = ({
               <SubcalculationColumn>
                 <ContainerWithTooltip>
                   <SecondaryText fontSize={12} className="mr-auto">
-                    Boosted Rewards
+                    {t("webapp:TooltipExplanations:boostedRewards:title")}
                   </SecondaryText>
                   <TooltipExplanation
-                    title="Boosted Rewards"
-                    explanation="The additional rewards veRBN holders earn for staking their rTokens. Base rewards can be boosted by up to 2.5X."
+                    title={t("webapp:TooltipExplanations:boostedRewards:title")}
+                    explanation={t(
+                      "webapp:TooltipExplanations:boostedRewards:description"
+                    )}
                     renderContent={({ ref, ...triggerHandler }) => (
                       <HelpInfo containerRef={ref} {...triggerHandler}>
                         i

--- a/webapp/src/components/Staking/StakingOverview.tsx
+++ b/webapp/src/components/Staking/StakingOverview.tsx
@@ -199,7 +199,7 @@ const StakingOverview: React.FC<StakingOverviewProps> = ({
         const endStakeReward = moment.unix(lg5Data.periodEndTime);
 
         if (endStakeReward.diff(moment()) <= 0) {
-          return "Program Ended";
+          return "Now";
         }
 
         // Time till next stake reward date


### PR DESCRIPTION
- Shows current boost on gauge card
<img width="727" alt="Screenshot 2022-03-17 at 10 45 36 AM" src="https://user-images.githubusercontent.com/11567740/158782543-d9907805-d058-424a-a148-312014253271.png">

- Factored in current stake in staking modal when calculating the boost
<img width="456" alt="Screenshot 2022-03-17 at 10 45 40 AM" src="https://user-images.githubusercontent.com/11567740/158782634-2d0fe274-79d9-4537-8cf2-5c3869c867fc.png">

