### PR TITLE
Fix not refetching penalty rewards after claiming. Fixed claim toast …

### DIFF
--- a/governance/src/components/Common/toast.tsx
+++ b/governance/src/components/Common/toast.tsx
@@ -44,7 +44,15 @@ export const TxStatusToast = () => {
         return <ThemedLogo theme={colors.red} />;
       case "protocolRevenueClaim":
       case "protocolPenaltyClaim":
-        return <RevenueClaimIcon width="100%" height="100%" />;
+        return (
+          <RevenueClaimIcon
+            width="100%"
+            height="100%"
+            style={{
+              backgroundColor: colors.background.two,
+            }}
+          />
+        );
     }
     return undefined;
   }, []);

--- a/governance/src/components/FAB/StakingFab.tsx
+++ b/governance/src/components/FAB/StakingFab.tsx
@@ -118,7 +118,7 @@ const StakingFAB = () => {
     }
 
     return "stake";
-  }, [rbnAllowance, rbnTokenAccount, lockExpired]);
+  }, [rbnTokenAccount, lockExpired]);
 
   const fabInfo: {
     veRBNAmount: JSX.Element | string;

--- a/governance/src/components/RevenueClaim/RevenueClaimForm.tsx
+++ b/governance/src/components/RevenueClaim/RevenueClaimForm.tsx
@@ -111,15 +111,21 @@ const RevenueClaimForm: React.FC<RevenueClaimFormProps> = ({
       ? parseFloat(formatUnits(vaultRevenue, getAssetDecimals("WETH")))
       : undefined;
 
+    let vaultRevenueDisplay = "---";
+    if (vaultRevenueNum === undefined) {
+      vaultRevenueDisplay = "---";
+    } else if (vaultRevenueNum <= 0) {
+      vaultRevenueDisplay = "0.00";
+    } else if (vaultRevenueNum < 0.0001) {
+      vaultRevenueDisplay = "<0.0001";
+    } else {
+      vaultRevenueDisplay = vaultRevenueNum?.toFixed(4);
+    }
+
     return {
       Logo: getAssetLogo("WETH"),
       label: t("governance:RevenueClaim:vaultRevenueEarned"),
-      input:
-        vaultRevenueNum === undefined
-          ? "---"
-          : vaultRevenueNum < 0.0001
-          ? "<0.0001"
-          : vaultRevenueNum?.toFixed(4),
+      input: vaultRevenueDisplay,
     };
   }, [claimType, t, unlockPenalty, vaultRevenue]);
 

--- a/governance/src/components/RevenueClaim/RevenueClaimPreview.tsx
+++ b/governance/src/components/RevenueClaim/RevenueClaimPreview.tsx
@@ -42,6 +42,17 @@ const RevenueClaimPreview: React.FC<RevenueClaimPreviewProps> = ({
     ? parseFloat(formatUnits(vaultRevenue, getAssetDecimals("WETH")))
     : undefined;
 
+  let vaultRevenueDisplay = "---";
+  if (vaultRevenueNum === undefined) {
+    vaultRevenueDisplay = "---";
+  } else if (vaultRevenueNum <= 0) {
+    vaultRevenueDisplay = "0.00";
+  } else if (vaultRevenueNum < 0.0001) {
+    vaultRevenueDisplay = "<0.0001";
+  } else {
+    vaultRevenueDisplay = vaultRevenueNum?.toFixed(4);
+  }
+
   return (
     <>
       <ModalBackButton onBack={onBack} />
@@ -71,13 +82,7 @@ const RevenueClaimPreview: React.FC<RevenueClaimPreviewProps> = ({
       ) : (
         <ModalInfoColumn
           label={t("governance:RevenueClaim:protocolFees")}
-          data={
-            vaultRevenueNum === undefined
-              ? "---"
-              : vaultRevenueNum < 0.0001
-              ? "<0.0001"
-              : vaultRevenueNum?.toFixed(4)
-          }
+          data={vaultRevenueDisplay}
         />
       )}
       <BaseModalContentColumn marginTop="auto">


### PR DESCRIPTION
- Automatically re-fetch latest penalty + fee rewards on `claim()`
- Updated styling of "Claimed Successfully" toast icon